### PR TITLE
Add FullResourceId parameter

### DIFF
--- a/tableCreator tool/tableCreator.ps1
+++ b/tableCreator tool/tableCreator.ps1
@@ -18,16 +18,32 @@ param (
     [string]$type,
     [int]$retention,
     [int]$totalRetention,
-    [switch]$ConvertToString
+    [switch]$ConvertToString,
+    [ValidateScript({
+        if ($_ -match '^/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/resourcegroups/[a-zA-Z0-9-_]+/providers/microsoft.operationalinsights/workspaces/[a-zA-Z0-9-_]+$') {
+            $true
+        } else {
+            throw "`n'$_' doesn't look like a valid full resource ID. If provided, it needs to be the full resource ID."
+        }
+    })]
+    [string] $FullResourceId # From Log Analytics Workspace, hit 'JSON View' and then the copy button at the top of the JSON pane.
 )
 
 ##################################################################################################################
+# You can edit this ResourceID to make this script easy to re-use for one environment, 
+# or provide -FullResourceId on the command line each time.
+
 $resourceId = "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/YOUR_RESOURCE_GROUP/providers/Microsoft.OperationalInsights/workspaces/YOUR_WORKSPACE_NAME"
+
+# override with whatever the command line said, if it was used.
+if($FullResourceId){
+    $resourceId = $FullResourceId
+}
 ##################################################################################################################
 
 # Display the banner
 Write-Host " +=======================+"
-Write-Host " | tableCreator.ps1 v2.2 |"
+Write-Host " | tableCreator.ps1 v2.3 |"
 Write-Host " +=======================+"
 Write-Host ""
 


### PR DESCRIPTION
+ Adds FullResourceId parameter with validation for resource ID format.
+ Explains decisions around that parameter

Explanation:
I found I always needed to edit the script before running it across many environments, and I'd rather provide a resource ID on the command line than edit the script.

Tested in private environment with no issues - table creation worked as per current script, validation disallowed invalid ID, no ID was assumed to be whatever was in the script.


(Also had issues forking and cloning on a Windows system... maybe due to aux.conf? Odd! So my copy is here: https://github.com/TristankMS/markos-table-creator/blob/main/tablecreator.ps1)