### PR TITLE
Add 15 Endpoint DLP columns to M365AuditGeneralAndDLPSolution schema

### DIFF
--- a/M365AuditGeneralAndDLPSolution/M365AuditGeneralAndDLPSolution.json
+++ b/M365AuditGeneralAndDLPSolution/M365AuditGeneralAndDLPSolution.json
@@ -1321,6 +1321,66 @@
                             {
                                 "name": "SensitiveInfoDetectionIsIncluded",
                                 "type": "boolean"
+                            },
+                            {
+                                "name": "SensitiveInfoTypeData",
+                                "type": "dynamic"
+                            },
+                            {
+                                "name": "PolicyMatchInfo",
+                                "type": "dynamic"
+                            },
+                            {
+                                "name": "MatchedPolicies",
+                                "type": "dynamic"
+                            },
+                            {
+                                "name": "DeviceName",
+                                "type": "string"
+                            },
+                            {
+                                "name": "TargetFilePath",
+                                "type": "string"
+                            },
+                            {
+                                "name": "Application",
+                                "type": "string"
+                            },
+                            {
+                                "name": "Sha256",
+                                "type": "string"
+                            },
+                            {
+                                "name": "Sha1",
+                                "type": "string"
+                            },
+                            {
+                                "name": "EnforcementMode",
+                                "type": "int"
+                            },
+                            {
+                                "name": "FileSize",
+                                "type": "long"
+                            },
+                            {
+                                "name": "FileType",
+                                "type": "string"
+                            },
+                            {
+                                "name": "SourceLocationType",
+                                "type": "int"
+                            },
+                            {
+                                "name": "DestinationLocationType",
+                                "type": "int"
+                            },
+                            {
+                                "name": "MDATPDeviceId",
+                                "type": "string"
+                            },
+                            {
+                                "name": "RMSEncrypted",
+                                "type": "boolean"
                             }
                         ]
                     }
@@ -2875,6 +2935,66 @@
                             "name": "SensitiveInfoDetectionIsIncluded",
                             "type": "boolean",
                             "description": "Indicates whether the event contains the value of the sensitive data type and surrounding context from the source content"
+                        },
+                        {
+                            "name": "SensitiveInfoTypeData",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "PolicyMatchInfo",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "MatchedPolicies",
+                            "type": "dynamic"
+                        },
+                        {
+                            "name": "DeviceName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "TargetFilePath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Application",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Sha256",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Sha1",
+                            "type": "string"
+                        },
+                        {
+                            "name": "EnforcementMode",
+                            "type": "int"
+                        },
+                        {
+                            "name": "FileSize",
+                            "type": "long"
+                        },
+                        {
+                            "name": "FileType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SourceLocationType",
+                            "type": "int"
+                        },
+                        {
+                            "name": "DestinationLocationType",
+                            "type": "int"
+                        },
+                        {
+                            "name": "MDATPDeviceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "RMSEncrypted",
+                            "type": "boolean"
                         }
                     ]
                 }
@@ -3006,7 +3126,7 @@
                     "id": "M365AuditGeneralCCP",
                     "title": "Microsoft 365 Audit.General",
                     "publisher": "Marko Lauren",
-                    "descriptionMarkdown": "Microsoft 365 Audit.General connector ingests generic audit logs from Microsoft 365 workloads **not covered by dedicated connectors** (such as Exchange, Sharepoint, Teams, Dynamics, Purview). Includes Copilot, Power BI, Viva suite, Defender for Office 365, eDiscovery, Security & Compliance, Sentinel platform operations, and more.\n\nM365AuditGeneral_CL table with **304 columns** captures detailed activity across Microsoft 365.\n\n**Prerequisites:** Entra ID app with Office 365 Management API permissions and Audit.General subscription.",
+                    "descriptionMarkdown": "Microsoft 365 Audit.General connector ingests generic audit logs from Microsoft 365 workloads **not covered by dedicated connectors** (such as Exchange, Sharepoint, Teams, Dynamics, Purview). Includes Copilot, Power BI, Viva suite, Defender for Office 365, eDiscovery, Security & Compliance, Sentinel platform operations, and more.\n\nM365AuditGeneral_CL table with **319 columns** captures detailed activity across Microsoft 365.\n\n**Prerequisites:** Entra ID app with Office 365 Management API permissions and Audit.General subscription.",
                     "graphQueriesTableName": "M365AuditGeneral_CL",
                     "graphQueries": [
                         {
@@ -3197,7 +3317,7 @@
                     "id": "M365AuditDLPCCP",
                     "title": "Microsoft 365 Audit.DLP",
                     "publisher": "Marko Lauren",
-                    "descriptionMarkdown": "Microsoft 365 Audit.DLP connector ingests **DLP events for all workloads** from the Office 365 Management Activity API.\\n\\nData is ingested to the same **M365AuditGeneral_CL** table with **304 columns** including dedicated DLP schema fields (SharePointMetaData, ExchangeMetaData, EndpointMetaData, ExceptionInfo, PolicyDetails, SensitiveInfoDetectionIsIncluded).\\n\\n**Prerequisites:** Entra ID app with Office 365 Management API permissions and DLP.All subscription.",
+                    "descriptionMarkdown": "Microsoft 365 Audit.DLP connector ingests **DLP events for all workloads** from the Office 365 Management Activity API.\\n\\nData is ingested to the same **M365AuditGeneral_CL** table with **319 columns** including dedicated DLP schema fields (SharePointMetaData, ExchangeMetaData, EndpointMetaData, ExceptionInfo, PolicyDetails, SensitiveInfoDetectionIsIncluded).\\n\\n**Prerequisites:** Entra ID app with Office 365 Management API permissions and DLP.All subscription.",
                     "graphQueriesTableName": "M365AuditGeneral_CL",
                     "graphQueries": [
                         {
@@ -3668,3 +3788,4 @@
         }
     ]
 }
+

--- a/M365AuditGeneralAndDLPSolution/M365AuditGeneralAndDLPSolution.json
+++ b/M365AuditGeneralAndDLPSolution/M365AuditGeneralAndDLPSolution.json
@@ -3126,7 +3126,7 @@
                     "id": "M365AuditGeneralCCP",
                     "title": "Microsoft 365 Audit.General",
                     "publisher": "Marko Lauren",
-                    "descriptionMarkdown": "Microsoft 365 Audit.General connector ingests generic audit logs from Microsoft 365 workloads **not covered by dedicated connectors** (such as Exchange, Sharepoint, Teams, Dynamics, Purview). Includes Copilot, Power BI, Viva suite, Defender for Office 365, eDiscovery, Security & Compliance, Sentinel platform operations, and more.\n\nM365AuditGeneral_CL table with **319 columns** captures detailed activity across Microsoft 365.\n\n**Prerequisites:** Entra ID app with Office 365 Management API permissions and Audit.General subscription.",
+                    "descriptionMarkdown": "Microsoft 365 Audit.General connector ingests generic audit logs from Microsoft 365 workloads **not covered by dedicated connectors** (such as Exchange, SharePoint, Teams, Dynamics, Purview). Includes Copilot, Power BI, Viva suite, Defender for Office 365, eDiscovery, Security & Compliance, Sentinel platform operations, and more.\n\nM365AuditGeneral_CL table with **319 columns** captures detailed activity across Microsoft 365.\n\n**Prerequisites:** Entra ID app with Office 365 Management API permissions and Audit.General subscription.",
                     "graphQueriesTableName": "M365AuditGeneral_CL",
                     "graphQueries": [
                         {


### PR DESCRIPTION
## Summary

This PR adds 15 missing Endpoint DLP-specific columns to the `M365AuditGeneral_CL` table schema and `Custom-M365AuditGeneralInput` stream declaration in the ARM template.

## Problem

When Endpoint DLP policy match events (RecordType 63 / DLPEndpoint) are ingested via the `Audit.General` content type, the Office 365 Management Activity API returns DLP-specific nested fields such as `SensitiveInfoTypeData`, `PolicyMatchInfo`, `DeviceName`, `Sha256`, etc. However, these fields are not defined in the current table schema (304 columns), causing them to be silently dropped during ingestion.

This means that while Sentinel shows *that* a DLP policy match occurred (via `Operation`, `RecordType`, `ObjectId`), it cannot show *which* policy matched, *which* sensitive information types were detected, or file-level details.

## Changes

- **Table schema**: Added 15 columns (304 → 319)
- **Stream declaration**: Added same 15 columns (304 → 319)
- **Description text**: Updated column count references from 304 to 319

### New Columns

| Column | Type | Description |
|--------|------|-------------|
| `SensitiveInfoTypeData` | dynamic | SIT detection results (SIT ID, count, confidence) |
| `PolicyMatchInfo` | dynamic | Primary DLP policy match info |
| `MatchedPolicies` | dynamic | Array of all matched policies |
| `DeviceName` | string | Device FQDN |
| `TargetFilePath` | string | Target file path |
| `Application` | string | Triggering application |
| `Sha256` | string | SHA-256 file hash |
| `Sha1` | string | SHA-1 file hash |
| `EnforcementMode` | int | DLP enforcement mode |
| `FileSize` | long | File size (bytes) |
| `FileType` | string | File type classification |
| `SourceLocationType` | int | Source location type |
| `DestinationLocationType` | int | Destination location type |
| `MDATPDeviceId` | string | MDE device ID |
| `RMSEncrypted` | boolean | RMS encryption flag |

## Testing

Tested in a lab environment:
1. Deployed the solution and triggered Endpoint DLP policy match events on a Windows 11 device
2. Confirmed the O365 Management API (`Audit.General`) returns all 15 fields for `RecordType 63` / `FileModified` events
3. Added the 15 columns to an existing deployment via REST API (table + DCR stream)
4. Verified all 15 columns (including `dynamic` type) populate correctly via direct Data Collection Endpoint ingest

## Notes

- The template already includes generic DLP fields (`PolicyDetails`, `SensitiveInfoDetectionIsIncluded`) but the API uses different field names for Endpoint DLP events
- Existing deployments can add these columns via `az monitor log-analytics workspace table update` + DCR stream update without redeployment