### PR TITLE
Add EvaluationSource and IncidentId columns for DLP.All events (319 -> 321)

### DIFF
--- a/M365AuditGeneralAndDLPSolution/M365AuditGeneralAndDLPSolution.json
+++ b/M365AuditGeneralAndDLPSolution/M365AuditGeneralAndDLPSolution.json
@@ -61,7 +61,7 @@
         "_solutionName": "Microsoft 365 Audit General & DLP",
         "_solutionVersion": "1.0.0",
         "_solutionAuthor": "Marko Lauren",
-        "_packageIcon": "\u003cimg src=\"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Logos/Microsoft_logo.svg\" width=\"75px\" height=\"75px\"\u003e",
+        "_packageIcon": "<img src=\"https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/Logos/Microsoft_logo.svg\" width=\"75px\" height=\"75px\">",
         "_solutionId": "azuresentinel.azure-sentinel-solution-microsoft365auditgeneraldlp",
         "dataConnectorVersionConnectorDefinition": "1.0.0",
         "dataConnectorVersionConnections": "1.0.0",
@@ -1381,6 +1381,14 @@
                             {
                                 "name": "RMSEncrypted",
                                 "type": "boolean"
+                            },
+                            {
+                                "name": "EvaluationSource",
+                                "type": "string"
+                            },
+                            {
+                                "name": "IncidentId",
+                                "type": "string"
                             }
                         ]
                     }
@@ -2995,6 +3003,16 @@
                         {
                             "name": "RMSEncrypted",
                             "type": "boolean"
+                        },
+                        {
+                            "name": "EvaluationSource",
+                            "type": "string",
+                            "description": "DLP evaluation source (e.g., DlpPolicyEventBasedAssistantOneDriveForBusiness)"
+                        },
+                        {
+                            "name": "IncidentId",
+                            "type": "string",
+                            "description": "DLP incident identifier (GUID)"
                         }
                     ]
                 }
@@ -3023,7 +3041,9 @@
                     "tier": "Community"
                 },
                 "categories": {
-                    "domains": ["Cloud Provider"],
+                    "domains": [
+                        "Cloud Provider"
+                    ],
                     "verticals": []
                 },
                 "dependencies": {
@@ -3184,15 +3204,15 @@
                     "instructionSteps": [
                         {
                             "title": "1. Register an Entra ID Application",
-                            "description": "⚠️ If you already have an app from the Audit.DLP connector, you can **reuse the same app**. Otherwise:\\n\\n1. Go to **Microsoft Entra ID** \u003e **App registrations** \u003e **New registration**\n2. Name: `Sentinel-M365AuditGeneral` (or your preferred name)\n3. **Supported account types**: Accounts in this organizational directory only\n4. Click **Register**\n5. Note the **Application (client) ID** - you'll need this later\n6. Go to **Certificates \u0026 secrets** \u003e **New client secret**\n7. Add a description, set expiration, click **Add**\n8. **Copy the secret Value immediately** - it won't be shown again"
+                            "description": "⚠️ If you already have an app from the Audit.DLP connector, you can **reuse the same app**. Otherwise:\\n\\n1. Go to **Microsoft Entra ID** > **App registrations** > **New registration**\n2. Name: `Sentinel-M365AuditGeneral` (or your preferred name)\n3. **Supported account types**: Accounts in this organizational directory only\n4. Click **Register**\n5. Note the **Application (client) ID** - you'll need this later\n6. Go to **Certificates & secrets** > **New client secret**\n7. Add a description, set expiration, click **Add**\n8. **Copy the secret Value immediately** - it won't be shown again"
                         },
                         {
                             "title": "2. Configure API Permissions",
-                            "description": "⚠️ Audit.General requires **ActivityFeed.Read** permission (different from Audit.DLP which needs ActivityFeed.ReadDlp).\n\n1. In your app registration, go to **API permissions** \u003e **Add a permission**\n2. Select **Office 365 Management APIs**\n3. Choose **Application permissions**\n4. Select **ActivityFeed.Read**\n5. Click **Add permissions**\n6. Click **Grant admin consent** for your tenant\n7. Verify the permission shows as **Granted**"
+                            "description": "⚠️ Audit.General requires **ActivityFeed.Read** permission (different from Audit.DLP which needs ActivityFeed.ReadDlp).\n\n1. In your app registration, go to **API permissions** > **Add a permission**\n2. Select **Office 365 Management APIs**\n3. Choose **Application permissions**\n4. Select **ActivityFeed.Read**\n5. Click **Add permissions**\n6. Click **Grant admin consent** for your tenant\n7. Verify the permission shows as **Granted**"
                         },
                         {
                             "title": "3. Subscribe to Audit.General Content",
-                            "description": "Run this PowerShell script to subscribe to the Audit.General content type (required before data flows):\n\n```powershell\n# Replace with your values\n$tenantId = 'YOUR_TENANT_ID'\n$clientId = 'YOUR_CLIENT_ID'\n$clientSecret = 'YOUR_CLIENT_SECRET'\n$publisherId = $tenantId  # Publisher identifier is your tenant ID\n\n# Get OAuth token\n$body = @{\n    grant_type    = 'client_credentials'\n    client_id     = $clientId\n    client_secret = $clientSecret\n    resource      = 'https://manage.office.com'\n}\n$tokenResponse = Invoke-RestMethod -Method Post -Uri \"https://login.microsoftonline.com/$tenantId/oauth2/token\" -Body $body\n$token = $tokenResponse.access_token\n\n# Start subscription\n$headers = @{Authorization = \"Bearer $token\"}\n$subscribeUri = \"https://manage.office.com/api/v1.0/$tenantId/activity/feed/subscriptions/start?contentType=Audit.General\u0026PublisherIdentifier=$publisherId\"\nInvoke-RestMethod -Method Post -Uri $subscribeUri -Headers $headers\n```"
+                            "description": "Run this PowerShell script to subscribe to the Audit.General content type (required before data flows):\n\n```powershell\n# Replace with your values\n$tenantId = 'YOUR_TENANT_ID'\n$clientId = 'YOUR_CLIENT_ID'\n$clientSecret = 'YOUR_CLIENT_SECRET'\n$publisherId = $tenantId  # Publisher identifier is your tenant ID\n\n# Get OAuth token\n$body = @{\n    grant_type    = 'client_credentials'\n    client_id     = $clientId\n    client_secret = $clientSecret\n    resource      = 'https://manage.office.com'\n}\n$tokenResponse = Invoke-RestMethod -Method Post -Uri \"https://login.microsoftonline.com/$tenantId/oauth2/token\" -Body $body\n$token = $tokenResponse.access_token\n\n# Start subscription\n$headers = @{Authorization = \"Bearer $token\"}\n$subscribeUri = \"https://manage.office.com/api/v1.0/$tenantId/activity/feed/subscriptions/start?contentType=Audit.General&PublisherIdentifier=$publisherId\"\nInvoke-RestMethod -Method Post -Uri $subscribeUri -Headers $headers\n```"
                         },
                         {
                             "title": "4. Connect the Data Connector",
@@ -3379,7 +3399,7 @@
                     "instructionSteps": [
                         {
                             "title": "1. Register an Entra ID Application",
-                            "description": "⚠️ If you already have an app from the Audit.General connector, you can **reuse the same app**. Otherwise:\\n\\n1. Go to **Microsoft Entra ID** \u003e **App registrations** \u003e **New registration**\\n2. Name: `Sentinel-M365Audit` (or your preferred name)\\n3. **Supported account types**: Accounts in this organizational directory only\\n4. Click **Register**\\n5. Note the **Application (client) ID** - you'll need this later\\n6. Go to **Certificates \u0026 secrets** \u003e **New client secret**\\n7. Add a description, set expiration, click **Add**\\n8. **Copy the secret Value immediately** - it won't be shown again"
+                            "description": "⚠️ If you already have an app from the Audit.General connector, you can **reuse the same app**. Otherwise:\\n\\n1. Go to **Microsoft Entra ID** > **App registrations** > **New registration**\\n2. Name: `Sentinel-M365Audit` (or your preferred name)\\n3. **Supported account types**: Accounts in this organizational directory only\\n4. Click **Register**\\n5. Note the **Application (client) ID** - you'll need this later\\n6. Go to **Certificates & secrets** > **New client secret**\\n7. Add a description, set expiration, click **Add**\\n8. **Copy the secret Value immediately** - it won't be shown again"
                         },
                         {
                             "title": "2. Configure API Permissions",
@@ -3788,4 +3808,3 @@
         }
     ]
 }
-

--- a/M365AuditGeneralAndDLPSolution/README.md
+++ b/M365AuditGeneralAndDLPSolution/README.md
@@ -10,7 +10,7 @@ This solution provides **two codeless connectors (CCF)** for ingesting Microsoft
 
 ## Overview
 
-These connectors use the **Office 365 Management Activity API** to retrieve Microsoft 365 audit logs into a shared **304-column schema** covering **30 specialty workload types**:
+These connectors use the **Office 365 Management Activity API** to retrieve Microsoft 365 audit logs into a shared **321-column schema** covering **30 specialty workload types**:
 
 - **Audit.General connector**: 29 specialty workloads (Copilot, Power BI, Viva suite, Security & Compliance, eDiscovery, Sentinel platform, etc.)
 - **Audit.DLP connector**: Data loss prevention (DLP) events in Microsoft Purview available for Exchange Online, Endpoint(devices), and SharePoint and OneDrive.
@@ -120,7 +120,7 @@ The connector uses `"rateLimitQPS": 10` to control the maximum number of API req
 
 ## Data Schema
 
-Both connectors ingest data into the **shared** `M365AuditGeneral_CL` custom table with **304 columns** covering **30 workload schemas** (29 from Audit.General + 1 DLP schema).
+Both connectors ingest data into the **shared** `M365AuditGeneral_CL` custom table with **321 columns** covering **30 workload schemas** (29 from Audit.General + 1 DLP schema).
 
 ### Core Common Fields (14 fields)
 
@@ -177,7 +177,7 @@ The schema includes dedicated typed columns for 30 specialty workloads:
 - **Microsoft Sentinel Data Lake** (42 fields): Notebooks, Jobs, KQL queries, AI Tools, Graph operations, lake onboarding
 - **DLP (Data Loss Prevention)** (6 fields): SharePointMetaData, ExchangeMetaData, EndpointMetaData, ExceptionInfo, PolicyDetails, SensitiveInfoDetectionIsIncluded
 
-**Total Schema**: 304 columns utilizing 61% of Azure table capacity (500 column limit), leaving 39% headroom for future Microsoft API additions.
+**Total Schema**: 321 columns utilizing 64% of Azure table capacity (500 column limit), leaving 36% headroom for future Microsoft API additions.
 
 **Note**: DLP events from the DLP connector can be identified by filtering on `RecordType in (11, 13, 33, 63, 99, 100, 107, 187)`.
 
@@ -188,7 +188,7 @@ The solution creates a complete dual-connector data ingestion pipeline with **sh
 ### Deployed Resources:
 - **Data Collection Endpoint (DCE)**: `dce-m365-auditgeneral` - Shared network endpoint for secure data ingestion
 - **Data Collection Rule (DCR)**: `dcr-m365-auditgeneral` - Shared data stream definition with transformation logic and filtering
-- **Custom Table**: `M365AuditGeneral_CL` - Shared Log Analytics table with 304 structured columns covering 30 workload schemas
+- **Custom Table**: `M365AuditGeneral_CL` - Shared Log Analytics table with 321 structured columns covering 30 workload schemas
 - **Audit.General Data Connector**: RestApiPoller for Audit.General content type
 - **Audit.DLP Data Connector**: RestApiPoller for DLP.All content type
 
@@ -218,7 +218,7 @@ Both connectors share the same DCE, DCR, and table - differing only in the API e
    - DCR applies KQL transform: `source | where RecordType != 21 and RecordType != 278 and RecordType != 25 and RecordType != 71 and RecordType != 72 and RecordType != 75 and RecordType != 82 and RecordType != 83 and RecordType != 84 and RecordType != 93 and RecordType != 94 and RecordType != 95 and RecordType != 96 and RecordType != 97`
    - **Intelligent filtering**: Excludes Dynamics 365 (RecordTypes 21, 278), Teams (RecordType 25), and Microsoft Purview Information Protection (RecordTypes 71, 72, 75, 82, 83, 84, 93, 94, 95, 96, 97) events to avoid duplication with dedicated connectors
    - **Automatic type mapping**: DCR engine handles type conversions based on schema declarations
-   - Projects 304 structured columns across 30 workload schemas
+   - Projects 321 structured columns across 30 workload schemas
 
 6. **Ingestion**:
    - Transformed data sent to custom table via DCE
@@ -252,13 +252,13 @@ Contributions are welcome! Please submit pull requests or open issues for bugs a
 
 ### Version 1.0.0
 - **Dual-connector solution**: Audit.General + Audit.DLP connectors sharing infrastructure
-- **Comprehensive 304-column schema** covering 30 specialty workload types (29 general + 1 DLP)
+- **Comprehensive 321-column schema** covering 30 specialty workload types (29 general + 1 DLP)
 - **Shared infrastructure**: Both connectors use same DCE, DCR, and table - efficient resource utilization
 - **Intelligent filtering**: Excludes Dynamics 365 (RecordTypes 21, 278), Teams (RecordType 25), and Microsoft Purview Information Protection events (71, 72, 75, 82, 83, 84, 93, 94, 95, 96, 97) to avoid duplication with dedicated connectors
 - **Complete CCF (codeless connector framework) implementation**: DCE, DCR with KQL transformation, custom table, connector definition, OAuth 2.0 authentication
 - **Nested API calls**: Two-step content blob fetching pattern for efficient data retrieval
 - **Simplified deployment**: Single ARM template deploys both connectors with only 2 required parameters (workspace, workspace-location)
-- **Production-ready architecture**: Dependency management, proper column naming, type safety, 61% table capacity utilization
+- **Production-ready architecture**: Dependency management, proper column naming, type safety, 64% table capacity utilization
 
 ---
 

--- a/M365AuditGeneralAndDLPSolution/README.md
+++ b/M365AuditGeneralAndDLPSolution/README.md
@@ -120,7 +120,7 @@ The connector uses `"rateLimitQPS": 10` to control the maximum number of API req
 
 ## Data Schema
 
-Both connectors ingest data into the **shared** `M365AuditGeneral_CL` custom table with **321 columns** covering **30 workload schemas** (29 from Audit.General + 1 DLP schema).
+Both connectors ingest data into the **shared** `M365AuditGeneral_CL` custom table covering **30 workload schemas** (29 from Audit.General + 1 DLP schema).
 
 ### Core Common Fields (14 fields)
 
@@ -175,7 +175,7 @@ The schema includes dedicated typed columns for 30 specialty workloads:
 - **Data Center Security Base** (1 field): DataCenterSecurityEventType
 - **Data Center Security Cmdlet** (9 fields): ElevationTime, ElevationApprover, ElevationApprovedTime, ElevationRequestId, ElevationRole, ElevationDuration, GenericInfo, StartTime, EffectiveOrganization
 - **Microsoft Sentinel Data Lake** (42 fields): Notebooks, Jobs, KQL queries, AI Tools, Graph operations, lake onboarding
-- **DLP (Data Loss Prevention)** (6 fields): SharePointMetaData, ExchangeMetaData, EndpointMetaData, ExceptionInfo, PolicyDetails, SensitiveInfoDetectionIsIncluded
+- **DLP (Data Loss Prevention)** (10 fields): SharePointMetaData, ExchangeMetaData, EndpointMetaData, ExceptionInfo, PolicyDetails, SensitiveInfoDetectionIsIncluded, SensitiveInfoDetectionsData, SensitiveInfoTypeData, EvaluationSource, IncidentId
 
 **Total Schema**: 321 columns utilizing 64% of Azure table capacity (500 column limit), leaving 36% headroom for future Microsoft API additions.
 


### PR DESCRIPTION
## Summary

Add 2 missing columns to the table schema and DCR stream declaration that are present in DLP.All API responses but currently dropped during ingestion.

## Changes

- **Table schema**: 319 → 321 columns
- **DCR stream declaration**: 319 → 321 columns  
- **README**: Updated column counts (304 → 321) and capacity percentages (61% → 64%)

## New Columns

| Column | Type | Description | Present In |
|--------|------|-------------|-----------|
| `EvaluationSource` | string | DLP evaluation source (e.g., `DlpPolicyEventBasedAssistantOneDriveForBusiness`, `PolicyChangeEvaluationCrawlerSharePoint`) | RecordType 11 (ComplianceDLPSharePoint) |
| `IncidentId` | string | DLP incident GUID | RecordType 11, 13 (ComplianceDLPSharePoint, ComplianceDLPExchange) |

## Testing

Verified in a lab environment:
1. Added columns to deployed table + DCR via REST API
2. Triggered DLP events (OneDrive file upload with credit card numbers, Exchange email with sensitive data)
3. Confirmed both fields are populated in `M365AuditGeneral_CL` via CCF polling

## Note on README Column Count

The README previously referenced 304 columns, but the current ARM template contains 319 columns (after the 15 Endpoint DLP columns were added in the previous PR). This PR updates all README references to 321, reflecting both the previous addition and this one.